### PR TITLE
Close LocalHost when you close the PopUp!

### DIFF
--- a/SignInWindow.xaml.cs
+++ b/SignInWindow.xaml.cs
@@ -20,7 +20,6 @@ using System.Windows.Media;
 using System.Windows.Media.Imaging;
 using System.Windows.Shapes;
 using SpeckleCore;
-using System.Reflection;
 
 namespace SpecklePopup
 {

--- a/SignInWindow.xaml.cs
+++ b/SignInWindow.xaml.cs
@@ -106,7 +106,6 @@ namespace SpecklePopup
     public SignInWindow(bool isPopup = false)
     {
       this.DataContext = this;
-            Title = "Hello Stam";
       _isPopup = isPopup;
 
       InitializeComponent();

--- a/SignInWindow.xaml.cs
+++ b/SignInWindow.xaml.cs
@@ -20,6 +20,7 @@ using System.Windows.Media;
 using System.Windows.Media.Imaging;
 using System.Windows.Shapes;
 using SpeckleCore;
+using System.Reflection;
 
 namespace SpecklePopup
 {
@@ -102,17 +103,23 @@ namespace SpecklePopup
 
     //true if it's a popup wind0w. it will close automatically after selecting an account
     bool _isPopup;
-
+    
     public SignInWindow(bool isPopup = false)
     {
       this.DataContext = this;
-
+            Title = "Hello Stam";
       _isPopup = isPopup;
 
       InitializeComponent();
       accounts.CollectionChanged += Accounts_CollectionChanged;
-
+      Closing += TerminateHttpListener;
       LoadAccounts();
+    }
+
+    public void TerminateHttpListener(object sender, CancelEventArgs e)
+    {
+      if (listener != null)
+        listener.Abort();
     }
 
     private void Accounts_CollectionChanged(object sender, System.Collections.Specialized.NotifyCollectionChangedEventArgs e)

--- a/SpecklePopup.nuspec
+++ b/SpecklePopup.nuspec
@@ -4,13 +4,13 @@
     <id>$id$</id>
     <version>$version$</version>
     <title>$title$</title>
-    <authors>$author$</authors>
+    <authors>Speckle</authors>
     <owners>$author$</owners>
     <license type="expression">MIT</license>
     <projectUrl>https://github.com/speckleworks/SpeckleCore</projectUrl>
     <iconUrl>https://avatars2.githubusercontent.com/u/31284874</iconUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
-    <description>$description$</description>
+    <description>Annoying popup that allows you to choose or create a Speckle Account.</description>
     <releaseNotes></releaseNotes>
     <copyright>$copyright$</copyright>
     <tags>speckle popup accountmanager account</tags>


### PR DESCRIPTION
This is a quick fix for avoiding the dreaded localhost port 5050 is used error!

We are solving this by adding on the Closing event a method to close the listener